### PR TITLE
Improve testCoverageFilter by ignore DiffEngine and EmptyFiles

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -20,7 +20,7 @@ BuildParameters.PrintParameters(Context);
 ToolSettings.SetToolSettings(
     context: Context,
     dupFinderExcludePattern: new string[] { BuildParameters.RootDirectoryPath + "/src/Cake.Issues.DocFx.Tests/*.cs", BuildParameters.RootDirectoryPath + "/src/Cake.Issues.DocFx*/**/*.AssemblyInfo.cs" },
-    testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues]* -[Cake.Issues.Testing]* -[Shouldly]*",
+    testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues]* -[Cake.Issues.Testing]* -[Shouldly]* -[DiffEngine]* -[EmptyFiles]*",
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 


### PR DESCRIPTION
Improve testCoverageFilter by ignore `DiffEngine` and `EmptyFiles` will fix build issues.