### PR TITLE
Migrate from FxCop analyzers to NETAnalyzers

### DIFF
--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -9,19 +9,21 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
+  <PropertyGroup>
+    <DebugType>full</DebugType>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <DocumentationFile>bin\Debug\Cake.Issues.DocFx.xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\Cake.Issues.DocFx.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DocumentationFile>bin\Release\Cake.Issues.DocFx.xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Issues.DocFx.ruleset</CodeAnalysisRuleSet>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType>full</DebugType>
-  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Cake.Core">
       <Version>0.33.0</Version>
@@ -29,10 +31,9 @@
     <PackageReference Include="Cake.Issues">
       <Version>0.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.2</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add **AllEnabledByDefault**
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.
