### PR TITLE
Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.DocFx.nuspec
+++ b/nuspec/nuget/Cake.Issues.DocFx.nuspec
@@ -28,11 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net461/Cake.Issues.DocFx.dll" target="lib\net461" />
-    <file src="net461/Cake.Issues.DocFx.pdb" target="lib\net461" />
-    <file src="net461/Cake.Issues.DocFx.xml" target="lib\net461" />
-    <file src="netstandard2.0/Cake.Issues.DocFx.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.DocFx.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.DocFx.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1/Cake.Issues.DocFx.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.DocFx.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.DocFx.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0/Cake.Issues.DocFx.dll" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.DocFx.pdb" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.DocFx.xml" target="lib\net5.0" />
+    <file src="net6.0/Cake.Issues.DocFx.dll" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.DocFx.pdb" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.DocFx.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.DocFx addin</Description>
     <Authors>BBT Software AG</Authors>

--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>DocFx support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>


### PR DESCRIPTION
close #167 