### PR TITLE
Target Cake 2.0 instead of 2.2

### DIFF
--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" />
     <PackageReference Include="Cake.Issues.Testing" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="2.2.0" />
+    <PackageReference Include="Cake.Testing" Version="2.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.2.0" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Target Cake 2.0 instead of 2.2 to follow best practices as mentioned at https://cakebuild.net/docs/extending/addins/best-practices#cake-reference